### PR TITLE
Include commit hash in localization status data

### DIFF
--- a/.changeset/curvy-parrots-relax.md
+++ b/.changeset/curvy-parrots-relax.md
@@ -1,0 +1,5 @@
+---
+'@lunariajs/core': patch
+---
+
+Include commit hash in localization status data

--- a/packages/core/src/status/index.ts
+++ b/packages/core/src/status/index.ts
@@ -224,8 +224,10 @@ async function getFileData(
 		git: {
 			lastChange: toUtcString(lastCommit.date),
 			lastCommitMessage: lastCommit.message,
+			lastCommitHash: lastCommit.hash,
 			lastMajorChange: toUtcString(lastMajorCommit.date),
 			lastMajorCommitMessage: lastMajorCommit.message,
+			lastMajorCommitHash: lastMajorCommit.hash,
 		},
 	};
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,8 +3,10 @@ import type { OptionalKeys } from './config/index.js';
 export type GitHistory = {
 	lastChange: string;
 	lastCommitMessage: string;
+	lastCommitHash: string;
 	lastMajorChange: string;
 	lastMajorCommitMessage: string;
+	lastMajorCommitHash: string;
 };
 
 export type GitHosting = {


### PR DESCRIPTION
#### Description

Include the commit hashes in the generated `status.json` file.

This allows third-party tools to refer to the exact commits where the translation diff happened instead of relying on the timestamp of the commits increasing monotonically.