### PR TITLE
Fix source history incorrect listing

### DIFF
--- a/.changeset/early-tomatoes-reflect.md
+++ b/.changeset/early-tomatoes-reflect.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Fix source history incorrect listing

--- a/packages/core/src/status/index.ts
+++ b/packages/core/src/status/index.ts
@@ -60,10 +60,8 @@ export async function getLocalizationStatus(config: LunariaConfig, isShallowRepo
 					localizations[lang] = {
 						isMissing: true,
 						gitHostingFileURL: gitHostingLinks.create(localeFilePath),
-						gitHostingHistoryURL: gitHostingLinks.history(
-							sourceFile.path,
-							sourceFile.git.lastMajorChange
-						),
+						// When the file doesn't exist, we give it a clean history URL, without a since date.
+						gitHostingHistoryURL: gitHostingLinks.history(sourceFile.path),
 					};
 					break;
 				}
@@ -75,7 +73,7 @@ export async function getLocalizationStatus(config: LunariaConfig, isShallowRepo
 						isOutdated: sourceFile.git.lastMajorChange > localizationFile.git.lastMajorChange,
 						gitHostingHistoryURL: gitHostingLinks.history(
 							sourceFile.path,
-							sourceFile.git.lastMajorChange
+							localizationFile.git.lastMajorChange
 						),
 						meta: {
 							type: 'universal',
@@ -91,7 +89,7 @@ export async function getLocalizationStatus(config: LunariaConfig, isShallowRepo
 						isOutdated: sourceFile.git.lastMajorChange > localizationFile.git.lastMajorChange,
 						gitHostingHistoryURL: gitHostingLinks.history(
 							sourceFile.path,
-							sourceFile.git.lastMajorChange
+							localizationFile.git.lastMajorChange
 						),
 						meta: {
 							type: 'dictionary',


### PR DESCRIPTION
#### Description (required)

This PR fixes a regression with the `sinceDate` query parameter added to git hosting links. To be precise, the last major *source* change date was being given, while what was desired was the last *localization* major change date.